### PR TITLE
Fix fett_preprocess_eck_entity hook.

### DIFF
--- a/fett.theme
+++ b/fett.theme
@@ -226,19 +226,9 @@ function fett_preprocess_page_last(&$vars) {
  * Implements hook_preprocess_eck_entity().
  */
 function fett_preprocess_eck_entity(&$vars) {
-  $content = $vars['entity'];
-  $entity = '';
-  if (isset($content['#entity'])) {
-    $entity = $content['#entity'];
-  }
-  elseif (isset($content['#entity_type']) && isset($content['#' . $content['#entity_type']])) {
-    $entity = $content['#' . $content['#entity_type']];
-  }
-  if ($entity) {
-    $vars['attributes']['class'][] = Html::getClass($entity->getEntityTypeId());
-    $vars['attributes']['class'][] = Html::getClass($entity->bundle());
-    $vars['attributes']['class'][] = Html::getClass($content['#view_mode']);
-  }
+  $vars['attributes']['class'][] = Html::getClass($vars['entity_type']);
+  $vars['attributes']['class'][] = Html::getClass($vars['bundle']);
+  $vars['attributes']['class'][] = Html::getClass($vars['elements']['#view_mode']);
 }
 
 /**


### PR DESCRIPTION
Hooks may no longer use the ‘entity’ object, as its deprecated.

Modified hook to return same data without the utilizing the deprecated object.