### PR TITLE
Core 9.3.3: New theme requirements.

### DIFF
--- a/fett.info.yml
+++ b/fett.info.yml
@@ -2,7 +2,7 @@ name: Fett
 description: 'A front-end Drupal base theme of awesomeness built upon Zurb Foundation.'
 package: JaceRider
 type: theme
-core: 8.x
+core_version_requirement: ^8.8 || ^9
 screenshot: images/screenshot.png
 regions:
   header: Header
@@ -12,3 +12,4 @@ regions:
   sidebar_second: 'Sidebar second'
   footer_top: 'Footer Top'
   footer_bottom: 'Footer Bottom'
+base theme: false


### PR DESCRIPTION
Reference: https://www.drupal.org/node/3066038

May want the 'base theme' definition to be different.

May also be defined as 'stable[major-core-version]', e.g. 'stable9'. I'm not sure how that is supposed to work when the core_version_requirement is allowed to be '^8.8 || ^9'.